### PR TITLE
Adds support for switching audio tracks between scenes.

### DIFF
--- a/assets/js/interactivity.js
+++ b/assets/js/interactivity.js
@@ -20,4 +20,5 @@ export const interactivity = {
     updateContext: function(context) {
         document.querySelector("#main-scene").setAttribute('data-context', context);
     },
+    currentVolume: 0.1,
 };

--- a/controllers/scenes/scenes.js
+++ b/controllers/scenes/scenes.js
@@ -7,6 +7,8 @@ import "../../types/index.js";
  * Initializes the scene
  * 1. Transforms the text arrays into html
  * 2. Evaluates room darkness
+ * 3. Updates background music
+ * @param {string} sceneId
  * @returns {SceneModel} 
  */
 export function initializeController(sceneId) {
@@ -18,12 +20,14 @@ export function initializeController(sceneId) {
         dataStore.scenes[sceneId].commonState.showSceneStartItems = true;
     }
     setCurrentScene(sceneId);
+    updateBackgroundAudio(sceneId);
     return dataStore.scenes[sceneId];
 }
 
 /**
  * A sort of 'controller middleware', called by other controllers before
  * their own logic.
+ * @param {string} sceneId
  * @returns {void} 
  */
 export function updateController(sceneId) {
@@ -32,10 +36,12 @@ export function updateController(sceneId) {
         dataStore.scenes[sceneId].commonState.visited = true;
     }
     dataStore.scenes[sceneId].commonState.showSceneStartItems = false;
+    updateBackgroundAudio(sceneId);
 }
 
 /**
  * Reloads the scene when a player changes context
+ * @param {string} sceneId
  * @returns {SceneModel} 
  */
 export function contextualizeSceneRender(sceneId) {
@@ -46,18 +52,19 @@ export function contextualizeSceneRender(sceneId) {
 
 /**
  * Checks for start message, and if it exists, return a Message
+ * @param {string} sceneId
  * @returns {Message | null} 
  */
 export function startMessageController(sceneId) {
     updateController(sceneId);
     const startMessage = determineStartMessage(dataStore, sceneId);
-    console.log(startMessage);
     return startMessage ? dataStore.scenes[sceneId].messages[startMessage] : null;
 }
 
 /**
  * Access a message and returns it
- * @param {string} id
+ * @param {string} sceneId
+ * @param {string} messageId
  * @returns {Message | null} 
  */
 export function messageController(sceneId, messageId) {
@@ -68,11 +75,27 @@ export function messageController(sceneId, messageId) {
 
 /**
  * Access a decision and returns it
- * @param {string} id
+ * @param {string} sceneId
+ * @param {string} decisionId
  * @returns {Decision | null} 
  */
 export function decisionController(sceneId, decisionId) {
     updateController(sceneId);
     const decision = dataStore.scenes[sceneId].decisions[decisionId];
     return decision ? decision : null;
+}
+
+/**
+ * Compares currently playing bg music with a scene's listed track and updates accordingly
+ * @param {string} sceneId
+ * @returns {void} 
+ */
+function updateBackgroundAudio(sceneId) {
+    // TODO: Probably shouldn't let the scenes controller update the datastore global state?
+    if(dataStore.scenes[sceneId].audio == dataStore.globalState.currentAudio) {
+        dataStore.scenes[sceneId].audioUpdate = false;
+    } else {
+        dataStore.scenes[sceneId].audioUpdate = true;
+        dataStore.globalState.currentAudio = dataStore.scenes[sceneId].audio;
+    }
 }

--- a/models/index.js
+++ b/models/index.js
@@ -14,4 +14,7 @@ export const dataStore = {
     scenes: scenes,
     items: itemsModel,
     npcs: npcModel,
+    globalState: {
+        currentAudio: null,
+    },
 }

--- a/models/scenes/shrine.js
+++ b/models/scenes/shrine.js
@@ -17,6 +17,8 @@ export const shrineModel = {
         windowBroken: false,
     },
     areaTitle: "Western Wing",
+    audio: "/audio/Kingdom-in-Despair.mp3",
+    audioUpdate: false,
     basemats: {
         current: "image/shrine-no-candle-nyx.png",
     },

--- a/models/scenes/stairs.js
+++ b/models/scenes/stairs.js
@@ -15,6 +15,8 @@ export const stairsModel = {
     },
     uniqueState: {},
     areaTitle: null,
+    audio: "/audio/Dragon-Mystery_Looping.mp3",
+    audioUpdate: false,
     basemats: {
         current: "image/stairs-nyx.png",
     },

--- a/models/scenes/tunnel.js
+++ b/models/scenes/tunnel.js
@@ -15,6 +15,8 @@ export const tunnelModel = {
     },
     uniqueState: {},
     areaTitle: null,
+    audio: "/audio/Kingdom-in-Despair.mp3",
+    audioUpdate: false,
     basemats: {
         current: "image/tunnel-nyx.png",
     },

--- a/types/index.js
+++ b/types/index.js
@@ -4,11 +4,17 @@ import "./scenes.js";
 import "./npcs.js";
 
 /** 
+* @typedef GlobalState 
+* @prop {null | string} currentAudio
+*/
+
+/** 
 * @typedef DataStore 
 * @prop {PlayerModel} player  
 * @prop {SceneModels} scenes 
 * @prop {ItemsModel} items 
 * @prop {NPCModel} npcs 
+* @prop {GlobalState} globalState 
 */
 
 

--- a/types/scenes.js
+++ b/types/scenes.js
@@ -7,6 +7,8 @@
 * @prop {CommonState} commonState
 * @prop {UniqueState} uniqueState
 * @prop {string | null} areaTitle
+* @prop {string | null} audio
+* @prop {boolean} audioUpdate
 * @prop {Basemats} basemats
 * @prop {Fragments} fragments
 * @prop {Interactables} overlayNodes

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -12,32 +12,17 @@
 </head>
 
 <body>
-    <div id="audio">
-        <%- include('./partials/audio-player.ejs'); %>
-    </div>
     <div class="flex-centered">
         <div id="outer-container">
             <div id="main">
+                <%- include('./partials/main-menu'); %>
+                <div id="inventory-menu"></div>
                 <%- include('./partials/title-screen.ejs'); %>
             </div>
         </div>
     </div>
+
+    <%- include('./partials/audio-player.ejs'); %>
 </body>
-
-<script>
-    // htmx.logger = function(elt, event, data) {
-    //     if(console) {
-    //         console.log(event, elt, data);
-    //     }
-    // }
-
-
-    const audio = document.getElementById("audio-player");
-    let volumeControls = document.getElementById("volume-control");
-    audio.volume = 0; //set to 0 for development, 0.1 to listen
-    volumeControls.addEventListener("change", function(e) {
-        audio.volume = e.currentTarget.value / 100;
-    })
-</script>
 
 </html>

--- a/views/partials/audio-player.ejs
+++ b/views/partials/audio-player.ejs
@@ -1,4 +1,32 @@
-<!-- TODO: Make dynamic -->
-<audio id="audio-player" autoplay loop>
-    <source src="/audio/Dragon-Mystery_Looping.mp3" type="audio/mpeg">
-</audio>
+<!-- TODO: Make title screen data driven? -->
+<div id="audio">
+    <audio id="audio-player" autoplay loop>
+        <source src="/audio/Dragon-Mystery_Looping.mp3" type="audio/mpeg">
+    </audio>
+</div>
+
+<script>
+    // Sets the starting volume for background music. Value should be same as whatever is set in interactivity.js
+    document.getElementById("audio-player").volume = 0.1;
+
+    // Volume slider in Menu
+    let volumeControls = document.getElementById("volume-control");
+    volumeControls.addEventListener("change", function(e) {
+        document.getElementById("audio-player").volume = e.currentTarget.value / 100;
+        document.getElementById("volume-label-value").innerText = e.currentTarget.value;
+        window.interactivity.currentVolume = e.currentTarget.value / 100;
+    })
+
+    // Mutation observer that sets the volume and plays audio whenever the element is updated
+    const targetNode = document.getElementById("audio");
+    const config = { childList: true };
+
+    const updateBackgroundAudio = () => {
+        const audio = document.getElementById("audio-player");
+        audio.volume = window.interactivity.currentVolume || 0.1;
+        audio.play();
+    };
+
+    const observer = new MutationObserver(updateBackgroundAudio);
+    observer.observe(targetNode, config);
+</script>

--- a/views/partials/main-menu.ejs
+++ b/views/partials/main-menu.ejs
@@ -4,7 +4,8 @@
         <h1>Main Menu</h1>
         <hr/>
         <p>Volume</p>
-        <input type="range" id="volume-control" value="0">
+        <input type="range" id="volume-control" value="10">
+        <label for="volume-control"><span id="volume-label-value">10</span>%</label>
     </div>
 </div>
 

--- a/views/partials/main-wrapper.ejs
+++ b/views/partials/main-wrapper.ejs
@@ -1,4 +1,0 @@
-<%- include('./partials/menu-bar'); %>
-<%- include('./partials/main-menu'); %>
-<%- include('./partials/context-bar'); %>
-<div id="inventory-menu"></div>

--- a/views/partials/scene.ejs
+++ b/views/partials/scene.ejs
@@ -41,4 +41,11 @@
     />
   </div>
 </div>
+
+<% if (audioUpdate) { %>
+<audio id="audio-player" loop 
+  hx-swap-oob="true">
+  <source src="<%= audio %>" type="audio/mpeg">
+</audio>
+<% } %>
   

--- a/views/partials/starting-scene.ejs
+++ b/views/partials/starting-scene.ejs
@@ -1,15 +1,12 @@
-<div id="main">
-    <%- include('../partials/menu-bar'); %>
-    <%- include('../partials/main-menu'); %>
-    <%- include('../partials/context-bar'); %>
-    <div id="inventory-menu"></div>
-    <!-- TODO: Make starting scene dynamic -->
-    <div 
-        id="main-scene" 
-        hx-get="/scenes/init?sceneId=shrine" 
-        hx-swap="outerHTML" 
-        hx-select="#main-scene" 
-        class="transition"
-        hx-trigger="load">
-    </div>
+<%- include('../partials/menu-bar'); %>
+<%- include('../partials/context-bar'); %>
+
+<!-- TODO: Make starting scene dynamic -->
+<div 
+    id="main-scene" 
+    hx-get="/scenes/init?sceneId=shrine" 
+    hx-swap="outerHTML" 
+    hx-select="#main-scene" 
+    class="transition"
+    hx-trigger="load">
 </div>


### PR DESCRIPTION
### Description

For a while now there has been limited support for background audio tracks. This pull request sets the game up to allow different scenes to have their own audio tracks and play them. It also updates the volume slider in the main menu to show the percent value in text.

Addresses issue #8 

### Details
- A new 'global state' was added to the data store. This is needed to track the current audio between scene transitions, and it isn't tied to the player.
- Client-side currentVolume is tracked in window.interactivity
- Initial audio values are set in audio-player.ejs along with the volume control listener logic and a new mutation observer
- An out-of-band audio player element was added to the scene.ejs
- Scene models were updated to have both an audio track property and an audioUpdate property
- Scene controllers have logic to compare the scene's audio track with the global state and update values as needed
- Whenever a scene re-renders, if audioUpdate is true, it will update the audio-player element with a new source
- The mutation observer then sets the volume (stored in the client-side window) and plays the track